### PR TITLE
【Fixed】チーム情報の操作に関しての機能を整えること

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -26,22 +26,26 @@ class AssignsController < ApplicationController
   end
 
   def assign_destroy(assign, assigned_user)
-    if assigned_user == assign.team.owner
-      I18n.t('views.messages.cannot_delete_the_leader')
-    elsif Assign.where(user_id: assigned_user.id).count == 1
-      I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assign.destroy
-      set_next_team(assign, assigned_user)
-      I18n.t('views.messages.delete_member')
+    if assign.team.is_owner_or_yourself?(assign, current_user)
+      if assigned_user == assign.team.owner
+        I18n.t('views.messages.cannot_delete_the_leader')
+      elsif Assign.where(user_id: assigned_user.id).count == 1
+        I18n.t('views.messages.cannot_delete_only_a_member')
+      elsif assign.destroy
+        set_next_team(assign, assigned_user)
+        I18n.t('views.messages.delete_member')
+      else
+        I18n.t('views.messages.cannot_delete_member_4_some_reason')
+      end
     else
-      I18n.t('views.messages.cannot_delete_member_4_some_reason')
+      I18n.t('views.messages.cannot_delete_member_only_owner_or_salf')
     end
   end
-  
+
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
   end
-  
+
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :check_owner, only: %i[edit]
 
   def index
     @teams = Team.all
@@ -55,5 +56,11 @@ class TeamsController < ApplicationController
 
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
+  end
+
+  def check_owner
+    unless @team.owner_id == current_user.id
+      redirect_to teams_path, notice: '権限がないため、編集できません'
+    end
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -15,4 +15,8 @@ class Team < ApplicationRecord
   def invite_member(user)
     assigns.create(user: user)
   end
+
+  def is_owner_or_yourself?(assign, current_user)
+    self.owner_id == current_user.id || assign.user_id == current_user.id
+  end
 end

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -14,7 +14,11 @@
       <tr>
         <td><%= team.name %></td>
         <td><%= link_to 'Show', team %></td>
-        <td><%= link_to 'Edit', edit_team_path(team) %></td>
+        <% if team.owner == current_user %>
+          <td><%= link_to 'Edit', edit_team_path(team) %></td>
+        <% else %>
+          <td></td>
+        <% end %>
         <td><%= link_to 'Destroy', team, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -41,7 +41,9 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if @team.owner_id == current_user.id || assign.user_id == current_user.id %>
+                        <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -212,6 +212,7 @@ ja:
       failed_to_assign: 'アサインに失敗しました！'
       cannot_delete_the_leader: 'リーダーは削除できません。'
       cannot_delete_only_a_member: 'このユーザーはこのチームにしか所属していないため、削除できません。'
+      cannot_delete_member_only_owner_or_salf: '権限がないため、削除できません'
       delete_member: 'メンバーを削除しました。'
       cannot_delete_member_4_some_reason: 'なんらかの原因で、削除できませんでした。'
       failed_to_post: '投稿できませんでした...'


### PR DESCRIPTION
 #8
- Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
- TeamのeditはTeamのリーダー（オーナー）のみができるようにすること